### PR TITLE
feat: add sppl

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -14,17 +14,26 @@ jobs:
       with:
         nix_path: nixpkgs=channel:nixos-23.11
     - uses: DeterminateSystems/magic-nix-cache-action@v2
-    - run: |
+    - name:  build sppl
+      run: |
+        nix build \
+          -L \
+          -o ./sppl \
+          '.#sppl'
+    - name:  build base image (not pushed)
+      run: |
         nix build \
           -L \
           -o ./imgBase \
           '.#ociImgBase'
-    - run: |
+    - name:  build Gensql Query image
+      run: |
         nix build \
           -L \
           -o ./imgGensqlQuery \
           '.#ociImgGensqlQuery'
-    - run: |
+    - name:  build Loom image
+      run: |
         nix build \
           -L \
           -o ./imgLoom \

--- a/flake.lock
+++ b/flake.lock
@@ -66,11 +66,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1712014858,
-        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
+        "lastModified": 1714641030,
+        "narHash": "sha256-yzcRNDoyVP7+SCNX0wmuDju1NUCt8Dz9+lyUXEI0dbI=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
+        "rev": "e5d10a24b66c3ea8f150e47dfdb0416ab7c3390e",
         "type": "github"
       },
       "original": {
@@ -122,11 +122,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1714126975,
-        "narHash": "sha256-if+OXJH5Zx+HAalHeEEZZUaDsLn3X1NQsCbRWxutbyo=",
+        "lastModified": 1714492402,
+        "narHash": "sha256-y/Hi90+fr0RXrnIA1+flhE7qhRT2124BGWQLTKsB/Z0=",
         "owner": "OpenGen",
         "repo": "GenSQL.query",
-        "rev": "08be109e6ce7cf31e6e4e50421088aaa1f973aba",
+        "rev": "32adb67ff07c1bba67255384adbe30d80d4e0f9f",
         "type": "github"
       },
       "original": {
@@ -177,20 +177,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "dir": "lib",
-        "lastModified": 1711703276,
-        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
-        "type": "github"
+        "lastModified": 1714640452,
+        "narHash": "sha256-QBx10+k6JWz6u7VsohfSw8g8hjdBZEf8CFzXH1/1Z94=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/50eb7ecf4cd0a5756d7275c8ba36790e5bd53e33.tar.gz"
       },
       "original": {
-        "dir": "lib",
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/50eb7ecf4cd0a5756d7275c8ba36790e5bd53e33.tar.gz"
       }
     },
     "nixpkgs-lib_2": {

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,8 @@
       # apps, and devshells are per system.
       perSystem = { config, self', inputs', pkgs, system, ... }:
       let
+        sppl = pkgs.callPackage ./pkgs/sppl {};
+
         ociImgBase = pkgs.callPackage ./pkgs/oci/base {
           inherit nixpkgs;
           basicTools = self.lib.basicTools;
@@ -46,6 +48,8 @@
         packages = loom.more_packages // {
           inherit
             loom
+            sppl
+
             ociImgBase
             ociImgGensqlQuery
             ociImgLoom
@@ -53,7 +57,7 @@
         };
       in {
         devShells.default = pkgs.mkShell {
-          buildInputs = [] ++ toolkit;
+          packages = [] ++ toolkit;
         };
 
         inherit packages;

--- a/flake.nix
+++ b/flake.nix
@@ -60,6 +60,14 @@
           packages = [] ++ toolkit;
         };
 
+        devShells.sppl = pkgs.mkShell {
+          packages
+            = [sppl]
+            ++ sppl.checkInputs
+            ++ toolkit
+          ;
+        };
+
         inherit packages;
       };
 

--- a/pkgs/sppl/default.nix
+++ b/pkgs/sppl/default.nix
@@ -1,0 +1,46 @@
+{ pkgs,
+  system,
+  ...
+}: let
+
+  # relies on specific versions of deps that are no longer present in
+  # nixpkgs stable; we must checkout a specific SHA
+  nixpkgs-sppl = import (pkgs.fetchFromGitHub {
+      owner = "nixos";
+      repo = "nixpkgs";
+      rev = "35a74aa665a681b60d68e3d3400fcaa11690ee50";
+      sha256 = "sha256-6qjgWliwYtFsEUl4/SjlUaUF9hSSfVoaRZzN6MCgslg=";
+    }) {inherit system;};
+  pypkgs = nixpkgs-sppl.python39Packages;
+
+  sppl = pypkgs.buildPythonPackage rec { # not in nixpkgs
+    pname = "sppl";
+    version = "2.0.4";
+
+    src = pypkgs.fetchPypi {
+      inherit pname version;
+      sha256 = "sha256-QAp77L8RpN86V4O8F1zNA8O/szm9hNa4wWFT13av6BE=";
+    };
+
+    propagatedBuildInputs = with pypkgs; [
+      astunparse
+      numpy
+      scipy
+      sympy
+    ];
+
+    checkInputs = with pypkgs; [
+      coverage
+      pytest
+      pytestCheckHook
+      pytest-timeout
+    ];
+
+    pytestFlagsArray = [ "--pyargs" "sppl" ];
+
+    pipInstallFlags = [ "--no-deps" ];
+
+    passthru.runtimePython = nixpkgs-sppl.python39.withPackages (p: [ sppl ]);
+  };
+
+in sppl

--- a/pkgs/sppl/default.nix
+++ b/pkgs/sppl/default.nix
@@ -8,8 +8,8 @@
   nixpkgs-sppl = import (pkgs.fetchFromGitHub {
       owner = "nixos";
       repo = "nixpkgs";
-      rev = "35a74aa665a681b60d68e3d3400fcaa11690ee50";
-      sha256 = "sha256-6qjgWliwYtFsEUl4/SjlUaUF9hSSfVoaRZzN6MCgslg=";
+      rev = "994df04c3c700fe9edb1b69b82ba3c627e5e04ff";
+      sha256 = "sha256-60hLkFqLRI+5XEeacXaVPHdl6m/P8rN2L4luLGxklqs=";
     }) {inherit system;};
   pypkgs = nixpkgs-sppl.python39Packages;
 
@@ -17,9 +17,12 @@
     pname = "sppl";
     version = "2.0.4";
 
-    src = pypkgs.fetchPypi {
-      inherit pname version;
-      sha256 = "sha256-QAp77L8RpN86V4O8F1zNA8O/szm9hNa4wWFT13av6BE=";
+    #  Use a  version of sppl that has Nixpkgs-compatible versions of some packages
+    src = pkgs.fetchFromGitHub {
+      owner = "probsys";
+      repo = "sppl";
+      rev = "ab6435648e56df1603c4d8d27029605c247cb9f5";
+      sha256 = "sha256-hFIR073wDRXyt8EqFkLZNDdGUjPTyWYOfDg5eGTjvz0=";
     };
 
     propagatedBuildInputs = with pypkgs; [
@@ -41,6 +44,7 @@
     pipInstallFlags = [ "--no-deps" ];
 
     passthru.runtimePython = nixpkgs-sppl.python39.withPackages (p: [ sppl ]);
+    passthru.checkInputs = checkInputs;
   };
 
 in sppl


### PR DESCRIPTION
Adds SPPL as a python package that will now be consumed from this repo like so:
```
nix  build github:OpenGen/nix#sppl
```

This invocation will not work  until  this is merged -- for now, you must specify a sha:
```
nix  build github:OpenGen/nix/85a5938b099488d963fe256c0011491da8fb5da9#sppl
```

Once this  is merged, we can update documentation and finish https://github.com/OpenGen/GenSQL.query/pull/110 . Then once that is in, we can also open a PR to have an OCI image built here (or there, if we configure the whole OpenGen org with Docker Hub credentials, instaed of just this repo).