### PR TITLE
feat: add OCI image with Loom on Python3

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -27,8 +27,8 @@ jobs:
     - run: |
         nix build \
           -L \
-          -o ./loom \
-          '.#loom'
+          -o ./imgLoom \
+          '.#ociImgLoom'
 
     - name: Login to Docker Hub
       # only run this  when running on main, because
@@ -44,3 +44,8 @@ jobs:
       run: |
         docker load -i ./imgGensqlQuery
         docker push --all-tags probcomp/gensql.query
+    - name: push loom
+      if: github.ref == 'refs/heads/main'
+      run: |
+        docker load -i ./imgLoom
+        docker push --all-tags probcomp/inferenceql.loom

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,8 @@
 
         toolkit = self.lib.basicTools pkgs;
 
-        loom = (self.lib.mkScopes pkgs).callPy3Package ./pkgs/loom { };
+        scopes = (self.lib.mkScopes pkgs);
+        loom = scopes.callPy3Package ./pkgs/loom { };
 
         ociImgLoom = pkgs.callPackage ./pkgs/oci/inferenceql.loom {
           inherit nixpkgs ociImgBase;

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
         # 1. Add foo to inputs
         # 2. Add foo as a parameter to the outputs function
         # 3. Add here: foo.flakeModule
-        ./lib/devtools
+        ./lib
         inputs.flake-parts.flakeModules.easyOverlay
       ];
       systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
@@ -36,35 +36,24 @@
 
         toolkit = self.lib.basicTools pkgs;
 
-        callPackage = pkgs.newScope (
-          pkgs
-          // { inherit callPackage; }
-          // packages
-        );
-        callPy3Package = pkgs.newScope (
-          pkgs
-          // pkgs.python3Packages
-          // { inherit callPackage; }
-          // packages
-        );
+        loom = (self.lib.mkScopes pkgs).callPy3Package ./pkgs/loom { };
 
-        packages = {
+        ociImgLoom = pkgs.callPackage ./pkgs/oci/inferenceql.loom {
+          inherit nixpkgs ociImgBase;
+        };
+
+        packages = loom.more_packages // {
           inherit
             ociImgBase
             ociImgGensqlQuery
+            ociImgLoom
           ;
-          
-          goftests = callPackage ./pkgs/goftests { };
-          parsable = callPackage ./pkgs/parsable { };
-          pymetis = callPackage ./pkgs/pymetis { };
-          distributions = callPackage ./pkgs/distributions { };
-          loom = callPy3Package ./pkgs/loom { };
         };
       in {
         devShells.default = pkgs.mkShell {
           buildInputs = [] ++ toolkit;
         };
-        
+
         inherit packages;
       };
 

--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,7 @@
 
         packages = loom.more_packages // {
           inherit
+            loom
             ociImgBase
             ociImgGensqlQuery
             ociImgLoom

--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,7 @@
         scopes = (self.lib.mkScopes pkgs);
         loom = scopes.callPy3Package ./pkgs/loom { };
 
-        ociImgLoom = pkgs.callPackage ./pkgs/oci/inferenceql.loom {
+        ociImgLoom = pkgs.callPackage ./pkgs/oci/gensql.loom {
           inherit nixpkgs ociImgBase;
         };
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,0 +1,6 @@
+_: {
+  flake.lib = {
+    basicTools = import ./devtools;
+    mkScopes = import ./mkScopes;
+  };
+}

--- a/lib/devtools/default.nix
+++ b/lib/devtools/default.nix
@@ -1,14 +1,10 @@
-_: {
-  flake = {
-    lib.basicTools = pkgs: with pkgs; [
-      coreutils
-      curl
-      file
-      gawk
-      git
-      gnugrep
-      gnused
-      which
-    ];
-  };
-}
+pkgs: with pkgs; [
+  coreutils
+  curl
+  file
+  gawk
+  git
+  gnugrep
+  gnused
+  which
+]

--- a/lib/mkScopes/default.nix
+++ b/lib/mkScopes/default.nix
@@ -1,0 +1,13 @@
+pkgs: let
+  callPackage = pkgs.newScope (
+    pkgs
+    // { inherit callPackage; }
+  );
+  callPy3Package = pkgs.newScope (
+    pkgs
+    // pkgs.python3Packages
+    // { inherit callPackage; }
+  );
+in {
+  inherit callPackage callPy3Package ;
+}

--- a/pkgs/distributions/default.nix
+++ b/pkgs/distributions/default.nix
@@ -91,7 +91,7 @@ python3Packages.buildPythonPackage {
 
   env.DISTRIBUTIONS_USE_PROTOBUF = 1;
 
-  # https://github.com/numba/numba/issues/8698#issuecomment-1584888063 
+  # https://github.com/numba/numba/issues/8698#issuecomment-1584888063
   env.NUMPY_EXPERIMENTAL_DTYPE_API = 1;
 
   pythonImportsCheck = [

--- a/pkgs/loom/default.nix
+++ b/pkgs/loom/default.nix
@@ -6,21 +6,18 @@
 , wheel
 , cpplint
 , cython_0
-, goftests
 , imageio
 , matplotlib
 , mock
 , nose
 , numpy
 , pandas
-, parsable
 , pep8
 , pkgs
 , protobuf3_20
 , pyflakes
 , python3Packages
 , pytest
-, pymetis
 , scikit-learn
 , scipy
 , simplejson
@@ -29,10 +26,14 @@
 , stdenv
 , zlib
 , eigen
-, distributions
 , gperftools
 }:
 let
+  goftests = callPackage ./../goftests { };
+  parsable = callPackage ./../parsable { };
+  pymetis = callPackage ./../pymetis { };
+  distributions = callPackage ./../distributions {inherit goftests parsable;};
+
   protobuf = protobuf3_20;
 
   version = "0.2.10";
@@ -118,7 +119,7 @@ buildPythonPackage {
     pyflakes
   ];
 
-  # https://github.com/numba/numba/issues/8698#issuecomment-1584888063 
+  # https://github.com/numba/numba/issues/8698#issuecomment-1584888063
   env.NUMPY_EXPERIMENTAL_DTYPE_API = 1;
 
   env.DISTRIBUTIONS_USE_PROTOBUF = 1;
@@ -178,6 +179,15 @@ buildPythonPackage {
   '';
 
   passthru.loom-cpp = loom-cpp;
+
+  passthru.more_packages = {
+    inherit
+      goftests
+      distributions
+      pymetis
+      parsable
+    ;
+  };
 
   passthru.tests.run = callPackage ./test.nix { inherit src; };
 

--- a/pkgs/oci/gensql.loom/default.nix
+++ b/pkgs/oci/gensql.loom/default.nix
@@ -12,7 +12,7 @@
 
   loom = scopes.callPy3Package ./../../loom { };
 in pkgs.dockerTools.buildLayeredImage {
-  name = "probcomp/inferenceql.loom";
+  name = "probcomp/gensql.loom";
   tag = systemWithLinux;
   fromImage = ociImgBase;
   contents = [ loom python ];

--- a/pkgs/oci/inferenceql.loom/default.nix
+++ b/pkgs/oci/inferenceql.loom/default.nix
@@ -1,0 +1,25 @@
+{ pkgs,
+  nixpkgs,
+  system,
+  ociImgBase,
+}: let
+  # in OCI context, whatever our host platform we want to build same arch but linux
+  systemWithLinux = builtins.replaceStrings [ "darwin" ] [ "linux" ] system;
+  crossPkgsLinux = nixpkgs.legacyPackages.${systemWithLinux};
+  python = crossPkgsLinux.python3;
+
+  scopes = (import ./../../../lib/mkScopes) pkgs;
+
+  loom = scopes.callPy3Package ./../../loom { };
+in pkgs.dockerTools.buildImage {
+  name = "probcomp/inferenceql.loom";
+  tag = systemWithLinux;
+  fromImage = ociImgBase;
+  copyToRoot = [ loom python ];
+  config = {
+    Cmd = [ "${python}/bin/python" "-m" "loom.tasks" ];
+    Env = [
+      "LOOM_STORE=/loom/store"
+    ];
+  };
+}

--- a/pkgs/oci/inferenceql.loom/default.nix
+++ b/pkgs/oci/inferenceql.loom/default.nix
@@ -8,14 +8,14 @@
   crossPkgsLinux = nixpkgs.legacyPackages.${systemWithLinux};
   python = crossPkgsLinux.python3;
 
-  scopes = (import ./../../../lib/mkScopes) pkgs;
+  scopes = (import ./../../../lib/mkScopes) crossPkgsLinux;
 
   loom = scopes.callPy3Package ./../../loom { };
-in pkgs.dockerTools.buildImage {
+in pkgs.dockerTools.buildLayeredImage {
   name = "probcomp/inferenceql.loom";
   tag = systemWithLinux;
   fromImage = ociImgBase;
-  copyToRoot = [ loom python ];
+  contents = [ loom python ];
   config = {
     Cmd = [ "${python}/bin/python" "-m" "loom.tasks" ];
     Env = [


### PR DESCRIPTION
This PR adds a Nix derivation for a layered OCI image that contains Loom and its dependencies for python3.

Note that currently, Loom's dependency `distributions` does not have a compilation pathway for ARM architectures, so although this defines packages on all architectures, you must build the image with `.#packages.x86_64-linux.ociImgLoom`.

Note that about half of the changes here are a refactor to support use of `callPy3Package` from `crossPkgsLinux`.