### PR TITLE
Rename iql to gensql

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -27,9 +27,9 @@ jobs:
     - run: |
         nix build \
           -L \
-          -o ./imgIqlQuery \
-          '.#ociImgIqlQuery'
+          -o ./imgGensqlQuery \
+          '.#ociImgGensqlQuery'
     - if: github.ref == 'refs/heads/main'
       run: |
-        docker load -i ./imgIqlQuery
-        docker push --all-tags probcomp/inferenceql.query
+        docker load -i ./imgGensqlQuery
+        docker push --all-tags probcomp/gensql.query

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# InferenceQL/nix
+# OpenGen/nix
 
-This repo holds Nix flake, modules, packages, and reusable utility Nix language code for use across the InferenceQL ecosystem.
+This repo holds Nix flake, modules, packages, and reusable utility Nix language code for use across the OpenGen ecosystem.
 
 ## Usage
 
@@ -9,7 +9,7 @@ This repo holds Nix flake, modules, packages, and reusable utility Nix language 
 Currently, you can build a package directly like so:
 
 ```bash
-nix build github.com:InferenceQL/nix#ociImgBase
+nix build github.com:OpenGen/nix#ociImgBase
 ```
 
 ### Import utility code
@@ -20,11 +20,11 @@ To access the `lib` code exported by this flake, declare this repo as a flake in
 {
   inputs = {
     nixpkgs.url = ...
-    iqlnix.url = "github:InferenceQL/nix";
+    gensqlnix.url = "github:OpenGen/nix";
   };
-  outputs = inputs@{ nixpkgs, iqlnix , ... }: let
+  outputs = inputs@{ nixpkgs, gensqlnix, ... }: let
     # call some function
-    toolbox = iqlnix.lib.basicTools "aarch64-darwin";
+    toolbox = gensqlnix.lib.basicTools "aarch64-darwin";
   in {
     ...
   };

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1702929109,
-        "narHash": "sha256-k5DGTFzkto/8xlY1B32441Jtp/VCgakzdmieB9HLMWw=",
+        "lastModified": 1713172900,
+        "narHash": "sha256-1HPffCAfi8PWbf8zcxmMR+Zfp5mqz4LtBYLOr8pL/2o=",
         "owner": "jlesquembre",
         "repo": "clj-nix",
-        "rev": "26cee183a691cabd113b0751a09ad6f381e6681f",
+        "rev": "2223155bdea15736ee1be7a9cc3dc33fd8ef1e44",
         "type": "github"
       },
       "original": {
@@ -23,7 +23,7 @@
     "devshell": {
       "inputs": {
         "nixpkgs": [
-          "iqlquery",
+          "gensqlquery",
           "clj-nix",
           "nixpkgs"
         ],
@@ -66,11 +66,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1709336216,
-        "narHash": "sha256-Dt/wOWeW6Sqm11Yh+2+t0dfEWxoMxGBvv3JpIocFl9E=",
+        "lastModified": 1712014858,
+        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2",
+        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
         "type": "github"
       },
       "original": {
@@ -101,11 +101,11 @@
         "nixpkgs-lib": "nixpkgs-lib_4"
       },
       "locked": {
-        "lastModified": 1706830856,
-        "narHash": "sha256-a0NYyp+h9hlb7ddVz4LUn1vT/PLwqfrWYcHMvFB1xYg=",
+        "lastModified": 1712014858,
+        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "b253292d9c0a5ead9bc98c4e9a26c6312e27d69f",
+        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
         "type": "github"
       },
       "original": {
@@ -114,7 +114,7 @@
         "type": "github"
       }
     },
-    "iqlquery": {
+    "gensqlquery": {
       "inputs": {
         "clj-nix": "clj-nix",
         "flake-parts": "flake-parts_3",
@@ -122,16 +122,16 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1710956070,
-        "narHash": "sha256-sgonEpcwheIlpM0PwHP3yO4UCntKbhiimzUUVZmdZ6k=",
-        "owner": "inferenceql",
-        "repo": "inferenceql.query",
-        "rev": "9cd372e042780cac173e57d2c46eb7df1ac02698",
+        "lastModified": 1714126975,
+        "narHash": "sha256-if+OXJH5Zx+HAalHeEEZZUaDsLn3X1NQsCbRWxutbyo=",
+        "owner": "OpenGen",
+        "repo": "GenSQL.query",
+        "rev": "08be109e6ce7cf31e6e4e50421088aaa1f973aba",
         "type": "github"
       },
       "original": {
-        "owner": "inferenceql",
-        "repo": "inferenceql.query",
+        "owner": "OpenGen",
+        "repo": "GenSQL.query",
         "type": "github"
       }
     },
@@ -140,7 +140,7 @@
         "flake-part": "flake-part",
         "flake-parts": "flake-parts_2",
         "nixpkgs": [
-          "iqlquery",
+          "gensqlquery",
           "clj-nix",
           "nixpkgs"
         ]
@@ -178,11 +178,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1709237383,
-        "narHash": "sha256-cy6ArO4k5qTx+l5o+0mL9f5fa86tYUX3ozE1S+Txlds=",
+        "lastModified": 1711703276,
+        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1536926ef5621b09bba54035ae2bb6d806d72ac8",
+        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
         "type": "github"
       },
       "original": {
@@ -232,11 +232,11 @@
     "nixpkgs-lib_4": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1706550542,
-        "narHash": "sha256-UcsnCG6wx++23yeER4Hg18CXWbgNpqNXcHIo5/1Y+hc=",
+        "lastModified": 1711703276,
+        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "97b17f32362e475016f942bbdfda4a4a72a8a652",
+        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
         "type": "github"
       },
       "original": {
@@ -249,11 +249,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1706718339,
-        "narHash": "sha256-S+S97c/HzkO2A/YsU7ZmNF9w2s7Xk6P8dzmfDdckzLs=",
+        "lastModified": 1713725259,
+        "narHash": "sha256-9ZR/Rbx5/Z/JZf5ehVNMoz/s5xjpP0a22tL6qNvLt5E=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "53fbe41cf76b6a685004194e38e889bc8857e8c2",
+        "rev": "a5e4bbcb4780c63c79c87d29ea409abf097de3f7",
         "type": "github"
       },
       "original": {
@@ -265,11 +265,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1710806803,
-        "narHash": "sha256-qrxvLS888pNJFwJdK+hf1wpRCSQcqA6W5+Ox202NDa0=",
+        "lastModified": 1714076141,
+        "narHash": "sha256-Drmja/f5MRHZCskS6mvzFqxEaZMeciScCTFxWVLqWEY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b06025f1533a1e07b6db3e75151caa155d1c7eb3",
+        "rev": "7bb2ccd8cdc44c91edba16c48d2c8f331fb3d856",
         "type": "github"
       },
       "original": {
@@ -282,7 +282,7 @@
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "iqlquery": "iqlquery",
+        "gensqlquery": "gensqlquery",
         "nixpkgs": "nixpkgs_3"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,10 +1,10 @@
 {
-  description = "Nix utilities and cross-repo build artifacts for inferenceql";
+  description = "Nix utilities and cross-repo build artifacts for OpenGen";
 
   inputs = {
     flake-parts.url = "github:hercules-ci/flake-parts";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    iqlquery.url = "github:inferenceql/inferenceql.query";
+    gensqlquery.url = "github:OpenGen/GenSQL.query";
   };
 
   outputs = inputs@{ self, nixpkgs, flake-parts, ... }:
@@ -29,9 +29,9 @@
           inherit nixpkgs;
           basicTools = self.lib.basicTools;
         };
-        ociImgIqlQuery = pkgs.callPackage ./pkgs/oci/inferenceql.query {
+        ociImgGensqlQuery = pkgs.callPackage ./pkgs/oci/gensql.query {
           inherit nixpkgs ociImgBase;
-          iqlquery = inputs.iqlquery;
+          gensqlquery = inputs.gensqlquery;
         };
 
         toolkit = self.lib.basicTools pkgs;
@@ -51,7 +51,7 @@
         packages = {
           inherit
             ociImgBase
-            ociImgIqlQuery
+            ociImgGensqlQuery
           ;
           
           goftests = callPackage ./pkgs/goftests { };

--- a/pkgs/oci/gensql.query/default.nix
+++ b/pkgs/oci/gensql.query/default.nix
@@ -1,20 +1,20 @@
 { pkgs,
   nixpkgs,
   system,
-  iqlquery,
+  gensqlquery,
   ociImgBase,
 }: let
   # in OCI context, whatever our host platform we want to build same arch but linux
   systemWithLinux = builtins.replaceStrings [ "darwin" ] [ "linux" ] system;
   crossPkgsLinux = nixpkgs.legacyPackages.${systemWithLinux};
 
-  ociBin = iqlquery.packages.${systemWithLinux}.bin;
+  ociBin = gensqlquery.packages.${systemWithLinux}.bin;
 in pkgs.dockerTools.buildImage {
-  name = "probcomp/inferenceql.query";
+  name = "probcomp/gensql.query";
   tag = systemWithLinux;
   fromImage = ociImgBase;
   copyToRoot = [ ociBin ];
   config = {
-    Cmd = [ "${ociBin}/bin/iql" ];
+    Cmd = [ "${ociBin}/bin/gensql" ];
   };
 }


### PR DESCRIPTION
@ships This was done with search-and-replace for the most part. Apologies, but if there's some Docker images that need renaming, I'm not aware of it.

I'm also not sure how to exercise or test it. I tried `nix build github.com:OpenGen/nix#ociImgBase` from the readme, and it failed. But when I checked out `main` and tried it, that failed, too.

Any guidance appreciated, here. Or, if you prefer to take this over, that's fine, too.