### PR TITLE
Fix Cython version

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -24,6 +24,11 @@ jobs:
           -L \
           -o ./imgGensqlQuery \
           '.#ociImgGensqlQuery'
+    - run: |
+        nix build \
+          -L \
+          -o ./loom \
+          '.#loom'
 
     - name: Login to Docker Hub
       # only run this  when running on main, because

--- a/flake.lock
+++ b/flake.lock
@@ -265,11 +265,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1714076141,
-        "narHash": "sha256-Drmja/f5MRHZCskS6mvzFqxEaZMeciScCTFxWVLqWEY=",
+        "lastModified": 1714253743,
+        "narHash": "sha256-mdTQw2XlariysyScCv2tTE45QSU9v/ezLcHJ22f0Nxc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7bb2ccd8cdc44c91edba16c48d2c8f331fb3d856",
+        "rev": "58a1abdbae3217ca6b702f03d3b35125d88a2994",
         "type": "github"
       },
       "original": {

--- a/pkgs/distributions/default.nix
+++ b/pkgs/distributions/default.nix
@@ -65,7 +65,7 @@ python3Packages.buildPythonPackage {
   propagatedBuildInputs = with python3Packages; [
     protobuf3_20
     protobuf
-    cython
+    cython_0
     numpy
     parsable
     scipy

--- a/pkgs/loom/default.nix
+++ b/pkgs/loom/default.nix
@@ -5,7 +5,7 @@
 , setuptools
 , wheel
 , cpplint
-, cython
+, cython_0
 , goftests
 , imageio
 , matplotlib
@@ -127,7 +127,7 @@ buildPythonPackage {
     loom-cpp
     contextlib2
     cpplint
-    cython
+    cython_0
     distributions
     distributions.distributions-shared
     goftests


### PR DESCRIPTION
Breaking change in nixpkgs caused wrong version of Cython to be referenced by Loom and Distributions packages.