### PR TITLE
fix: Don't login to Dockerhub unnecessarily

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -10,11 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Login to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        username: ${{ vars.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
     - uses: cachix/install-nix-action@v25
       with:
         nix_path: nixpkgs=channel:nixos-23.11
@@ -29,7 +24,18 @@ jobs:
           -L \
           -o ./imgGensqlQuery \
           '.#ociImgGensqlQuery'
-    - if: github.ref == 'refs/heads/main'
+
+    - name: Login to Docker Hub
+      # only run this  when running on main, because
+      # that is the only  time we need these creds;
+      # otherwise, Fork-based PRs cannot succeed
+      if: github.ref == 'refs/heads/main'
+      uses: docker/login-action@v3
+      with:
+        username: ${{ vars.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: push gensql query
+      if: github.ref == 'refs/heads/main'
       run: |
         docker load -i ./imgGensqlQuery
         docker push --all-tags probcomp/gensql.query


### PR DESCRIPTION
Automation currently pushes to dockerhub when merged to main; however, it  still logs  in on PR branches. Those creds are not accessible to forks, so prs like #8 cannot succeed until we condition this step too.