### PR TITLE
fix(loom): Set correct owner on moved repo contextlib2

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,9 @@ Native library for probability distributions in python used by Loom. NOTE: this 
 
 Other upstream python packages required by Distributions and/or Loom.
 
+#### `.#loom.ociImg`
+
+A Loom container image is also provided as a passthru attribute of `loom`. It can be built and loaded into your local Docker registry with the following command:
+```sh
+docker load -i $(nix build 'github:OpenGen/nix/loom-oci-img-attribute#loom.ociImg' --no-link --print-out-paths)
+```

--- a/pkgs/loom/default.nix
+++ b/pkgs/loom/default.nix
@@ -83,7 +83,7 @@ let
     # https://github.com/jazzband/contextlib2/pull/52
     # updated to support Python3
     src = fetchFromGitHub {
-      owner = "mr-c";
+      owner = "jazzband";
       repo = "contextlib2";
       rev = "b8b7eb8ecd9e012178b5dcec4313edded751a459";
       hash = "sha256-FSx/vKctoFl4NlwzNDa9eDNUXeW1J875/nB6of+5gQk=";


### PR DESCRIPTION
It seems contextlib2 repo was moved to a different owner without a redirect.